### PR TITLE
escapes spaces in cd command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Textmate 2 Bundle for the Elm language.
 ## Installation
 
 ```
-cd ~/Library/Application Support/Avian/Pristine Copy/Bundles/
+cd ~/Library/Application\ Support/Avian/Pristine\ Copy/Bundles/
 git clone https://github.com/fab1an/Elm.tmBundle.git
 ```
 


### PR DESCRIPTION
btw this assumed that directory Bundles exist but in my case I had to create it.